### PR TITLE
Fix for problem when rpc client wants to send content that is bigger than the send buffer size

### DIFF
--- a/Libraries/RPC/SocketOperations.cpp
+++ b/Libraries/RPC/SocketOperations.cpp
@@ -291,15 +291,7 @@ void SocketOperations::getConnection()
 			GD::fileDescriptorManager.shutdown(_fileDescriptor);
 			throw SocketOperationException("Could not set socket options for server " + ipAddress + " on port " + _port + ": " + strerror(errno));
 		}
-/*
-		int32_t writeBufSize = 32768;
-		if(setsockopt(_fileDescriptor->descriptor, SOL_SOCKET, SO_SNDBUF, (void*)&writeBufSize, sizeof(int32_t)) == -1)
-		{
-			freeaddrinfo(serverInfo);
-			GD::fileDescriptorManager.shutdown(_fileDescriptor);
-			throw SocketOperationException("Could not set socket sndbuf size for server " + ipAddress + " on port " + _port + ": " + strerror(errno));
-		}
-*/
+
 		if(!(fcntl(_fileDescriptor->descriptor, F_GETFL) & O_NONBLOCK))
 		{
 			if(fcntl(_fileDescriptor->descriptor, F_SETFL, fcntl(_fileDescriptor->descriptor, F_GETFL) | O_NONBLOCK) < 0)


### PR DESCRIPTION
I use a raspberry pi with 4 bidcos devices including two smoke detectors. This results in a big newDevices message after the init call (in my case it was >20000 bytes). Apparently there is a default send buffer size and in nonblocking operation, the call to send fails with EAGAIN (Resource temporarily unavailable). So the server receiving the newDevices message will receive an incomplete message.

I found out that I can query the default send buffer size using 

$ cat /proc/sys/net/ipv4/tcp_wmem
4096    16384   3843232

The three numbers represent min/default/max

I tried two things: 
- to increase send buffer size (SOL_SOCKET,SO_SNDBUF) to 32k 
- to set socket to blocking operation

Both resulted in a solution to the problem. So I am quite sure that it is the buffer size and produced a fix that uses "select" to query if a buffer can be read and has a while loop that splits the message into smaller chunks automatically.
