### PR TITLE
debuild optimizations

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ override_dh_auto_configure:
 	# All shell commands are supported
 
 override_dh_auto_build:
-	make config=release
+	dh_auto_build -- config=release
 
 override_dh_auto_install:
 	dh_testdir

--- a/debian/rules
+++ b/debian/rules
@@ -92,4 +92,4 @@ override_dh_strip:
 	dh_strip --dbg-package=homegear
 	
 %:
-	dh $@
+	dh $@ --parallel


### PR DESCRIPTION
- more clean ```override_dh_auto_build``` to keep original arguments. just puts the ```config=release``` at the end of the make call but keeps other parameters (i.e ```-jX``` for parallel builds).
- allow parallel builds (it uses ```-j1``` as default). But it allows to switch to parallel builds in the ```debuild``` call: ```debuild -eDEB_BUILD_OPTIONS="parallel=4" -us -uc``` So there is no change as long you don't change the ```debuild``` call.

The parallel build works at least on my amd64 debian jessie builds I tested.
I used the following to make it dynamic:
```
cpuCores=$(grep -c processor /proc/cpuinfo)
debuild -eDEB_BUILD_OPTIONS="parallel=${cpuCores}" -us -uc
```
With 4 cores I got a 3-4 times faster build (around 2 minutes against the 8 minutes without parallel).

***Note***: I have read there are some architectures where parallel builds doesn't work. So before changing all your build scripts to use the parallel build, I suggest to test it first on all supported distributions and architectures. I think this PR should work the same way as before if you don't change the ```debuild``` calls in the scripts.

***Note 2***: Parallel builds are currently a bit shaky, some components fails sometimes because dependencies did't finished yet. I will try to investigate a bit more, but maybe you already know which components are dependent of others. Do you know any possibility to define dependencies during a build to make parallel builds more robust?
One example I got right now is: ```homegear``` fails because ```rpc``` is did not finish.
But almost half of the fired parallel builds works, so if it's possible to make them more robust due build order dependencies (if possible) it would be nice.
