### PR TITLE
Update homegear.service

### DIFF
--- a/misc/System Config/homegear.service
+++ b/misc/System Config/homegear.service
@@ -9,5 +9,6 @@ WantedBy=multi-user.target
 Type=forking
 PIDFile=/var/run/homegear/homegear.pid
 TimeoutSec=300
+LimitRTPRIO=100
 ExecStartPre=/usr/bin/homegear -u homegear -g homegear -p /var/run/homegear/homegear.pid -pre
 ExecStart=/usr/bin/homegear -u homegear -g homegear -p /var/run/homegear/homegear.pid -d


### PR DESCRIPTION
Add `ulimit -r` equivalent to systemd. This removes homegear start log entry:
```
5/21/16 09:15:42.027 Could not set thread priority. The executing user does not have enough privileges. Please run "ulimit -r 100" before executing Homegear.
```

systemd docs for this: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
(search for `ulimit -r`)