### PR TITLE
Homegear quits when ntp-sync takes too long

### DIFF
--- a/misc/Scripts/Docker Image Creation/Homegear Build/CreateDockerHomegearBuild.sh
+++ b/misc/Scripts/Docker Image Creation/Homegear Build/CreateDockerHomegearBuild.sh
@@ -307,9 +307,10 @@ cleanUp homegear-insteon
 cleanUp homegear-max
 cleanUp homegear-philipshue
 cleanUp homegear-sonos
+cleanUp homegear-kodi
 
 EOF
-echo "if test -f libhomegear-base.deb && test -f homegear.deb && test -f homegear-homematicbidcos.deb && test -f homegear-homematicwired.deb && test -f homegear-insteon.deb && test -f homegear-max.deb && test -f homegear-philipshue.deb && test -f homegear-sonos.deb; then
+echo "if test -f libhomegear-base.deb && test -f homegear.deb && test -f homegear-homematicbidcos.deb && test -f homegear-homematicwired.deb && test -f homegear-insteon.deb && test -f homegear-max.deb && test -f homegear-philipshue.deb && test -f homegear-sonos.deb && test -f homegear-kodi.deb; then
 	isodate=`date +%Y%m%d`
 	mv libhomegear-base.deb libhomegear-base_\$[isodate]_${distlc}_${distver}_${arch}.deb
 	mv homegear.deb homegear_\$[isodate]_${distlc}_${distver}_${arch}.deb
@@ -319,6 +320,7 @@ echo "if test -f libhomegear-base.deb && test -f homegear.deb && test -f homegea
 	mv homegear-max.deb homegear-max_\$[isodate]_${distlc}_${distver}_${arch}.deb
 	mv homegear-philipshue.deb homegear-philipshue_\$[isodate]_${distlc}_${distver}_${arch}.deb
 	mv homegear-sonos.deb homegear-sonos_\$[isodate]_${distlc}_${distver}_${arch}.deb
+	mv homegear-kodi.deb homegear-kodi_\$[isodate]_${distlc}_${distver}_${arch}.deb
 	if test -f /build/UploadNightly.sh; then
 		/build/UploadNightly.sh
 	fi

--- a/misc/Scripts/Docker Image Creation/Homegear Build/CreateDockerHomegearBuild.sh
+++ b/misc/Scripts/Docker Image Creation/Homegear Build/CreateDockerHomegearBuild.sh
@@ -213,37 +213,50 @@ wget https://github.com/Homegear/libhomegear-base/archive/${1}.zip
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear-HomeMaticBidCoS/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear-HomeMaticWired/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear-Insteon/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear-MAX/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear-PhilipsHue/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
 rm ${1}.zip
+
 wget https://github.com/Homegear/Homegear-Sonos/archive/${1}.zip
+[ $? -ne 0 ] && exit 1
+unzip ${1}.zip
+[ $? -ne 0 ] && exit 1
+rm ${1}.zip
+
+wget https://github.com/Homegear/Homegear-Kodi/archive/${1}.zip
 [ $? -ne 0 ] && exit 1
 unzip ${1}.zip
 [ $? -ne 0 ] && exit 1
@@ -264,6 +277,7 @@ createPackage Homegear-Insteon $1 homegear-insteon
 createPackage Homegear-MAX $1 homegear-max
 createPackage Homegear-PhilipsHue $1 homegear-philipshue
 createPackage Homegear-Sonos $1 homegear-sonos
+createPackage Homegear-Kodi $1 homegear-kodi
 EOF
 chmod 755 $rootfs/build/CreateDebianPackage.sh
 sed -i "s/<DIST>/${dist}/g" $rootfs/build/CreateDebianPackage.sh

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -813,23 +813,14 @@ void startUp()
 				GD::out.printCritical("Critical: deleting temporary file \"" + GD::bl->settings.tempPath() + *i + "\": " + strerror(errno));
 			}
 		}
-
-		for(uint32_t i = 0; i < 100; ++i)
+		
+		while(BaseLib::HelperFunctions::getTime() < 1000000000000)
 		{
-			if(BaseLib::HelperFunctions::getTime() < 1000000000000)
-			{
-				GD::out.printWarning("Warning: Time is in the past. Waiting for ntp to set the time...");
-				std::this_thread::sleep_for(std::chrono::milliseconds(10000));
-			}
-			else break;
-		}
-		if(BaseLib::HelperFunctions::getTime() < 1000000000000)
-		{
-			GD::out.printCritical("Critical: Time is still in the past. Check that ntp is setup correctly and your internet connection is working. Exiting...");
-			exit(1);
+			GD::out.printWarning("Warning: Time is in the past. Waiting for ntp to set the time...");
+			std::this_thread::sleep_for(std::chrono::milliseconds(10000));
 		}
 
-		GD::bl->db->init();
+	GD::bl->db->init();
     	GD::bl->db->open(GD::bl->settings.databasePath(), GD::bl->settings.databaseSynchronous(), GD::bl->settings.databaseMemoryJournal(), GD::bl->settings.databaseWALJournal(), GD::bl->settings.databasePath() + ".bak");
     	if(!GD::bl->db->isOpen()) exitHomegear(1);
 


### PR DESCRIPTION
I have installed homegear on a RPi. After a power loss it takes some time for my router (which is the NTP server in my network) to re-establish the internet connection and to synchronize its time with external servers (sometimes more than 15 minutes). This delay causes homegear to exit. In my opinion, there is no need for homgear to exit when the sync takes too long. By this change, homegear will wait endlessly until the ntp sync is completed.